### PR TITLE
Use the HttpParams class from @angular/common/http instead of URLSearchParams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Bug fixes
 
+- Fix IE support by switching from URLSearchParams to HttpParams from @angular/common/http (Sune Wøller) 
+
 - When we change query string but not context, we request backend. (Thomas Desvenain)
 
 # 1.0.4 (2017-11-04)

--- a/src/lib/interfaces.ts
+++ b/src/lib/interfaces.ts
@@ -1,8 +1,27 @@
+import { HttpParams } from '@angular/common/http';
+import { HttpParameterCodec } from '@angular/common/http';
+
 export interface Target {
   component: any;
   context: {[key: string]: any};
   contextPath: string;
   path: string;
-  query: URLSearchParams;
+  query: HttpParams;
   view: string;
+}
+
+// Copy from angular/common/http/params until it becomes part of the public api
+// https://github.com/angular/angular/pull/20332
+export interface HttpParamsOptions {
+  /**
+   * String representation of the HTTP params in URL-query-string format. Mutually exclusive with
+   * `fromObject`.
+   */
+  fromString?: string;
+
+  /** Object map of the HTTP params. Mutally exclusive with `fromString`. */
+  fromObject?: {[param: string]: string | string[]};
+
+  /** Encoding codec used to parse and serialize the params. */
+  encoder?: HttpParameterCodec;
 }

--- a/src/lib/traverser.ts
+++ b/src/lib/traverser.ts
@@ -1,11 +1,12 @@
 import {Injectable} from '@angular/core';
 import {Location} from '@angular/common';
+import { HttpParams } from '@angular/common/http';
 import {BehaviorSubject} from 'rxjs/BehaviorSubject';
 import {Observable} from 'rxjs/Observable';
 import {Resolver} from './resolver';
 import {Marker} from './marker';
 import {Normalizer} from './normalizer';
-import {Target} from './interfaces';
+import {Target, HttpParamsOptions} from './interfaces';
 import 'rxjs/add/observable/of';
 
 @Injectable()
@@ -23,7 +24,7 @@ export class Traverser {
       context: {},
       contextPath: '',
       path: '',
-      query: new URLSearchParams(''),
+      query: new HttpParams(),
       view: 'view',
     });
   }
@@ -89,7 +90,7 @@ export class Traverser {
               contextPath: contextPath,
               view: view,
               component: component,
-              query: new URLSearchParams(queryString || '')
+              query: new HttpParams({ fromString: queryString || '' } as HttpParamsOptions)
             });
           }
         });

--- a/tests/src/app/traverser.spec.ts
+++ b/tests/src/app/traverser.spec.ts
@@ -17,7 +17,7 @@ import { AppComponent } from './app.component';
 import { FileComponent } from './file/file.component';
 import { FolderComponent } from './folder/folder.component';
 import { FileInfoComponent } from './file-info/file-info.component';
-import { Target } from '../../../src/lib/interfaces';
+import { Target } from 'angular-traversal';
 
 @Injectable()
 export class FakeResolver1 extends Resolver {
@@ -121,6 +121,8 @@ describe('Traverser', () => {
     expect(location.path()).toBe('/file1');
   }));
 
+
+  // target.query is a HttpParams object - see https://angular.io/api/common/http/HttpParams
   it('should get queryString at traverse', async(() => {
     const fixture = TestBed.createComponent(AppComponent);
     const traverser: Traverser = TestBed.get(Traverser);
@@ -129,6 +131,34 @@ describe('Traverser', () => {
       expect(target.path).toBe('/file1?format=pdf');
       expect(target.contextPath).toBe('/file1');
       expect(target.query.get('format')).toBe('pdf');
+    });
+  }));
+
+  it('should get multiple queryString items at traverse', async(() => {
+    const fixture = TestBed.createComponent(AppComponent);
+    const traverser: Traverser = TestBed.get(Traverser);
+    traverser.traverse('/file1?format=pdf&mykey=test');
+    traverser.target.subscribe((target: Target) => {
+      expect(target.path).toBe('/file1?format=pdf&mykey=test');
+      expect(target.contextPath).toBe('/file1');
+      expect(target.query.get('format')).toBe('pdf');
+      expect(target.query.get('mykey')).toBe('test');
+      expect(target.query.toString()).toBe('format=pdf&mykey=test');
+    });
+  }));
+
+  it('should get multiple queryString items with the same key (list items) at traverse', async(() => {
+    const fixture = TestBed.createComponent(AppComponent);
+    const traverser: Traverser = TestBed.get(Traverser);
+    traverser.traverse('/file1?formats=pdf&formats=doc');
+    traverser.target.subscribe((target: Target) => {
+      expect(target.path).toBe('/file1?formats=pdf&formats=doc');
+      expect(target.contextPath).toBe('/file1');
+      // get the first value for param
+      expect(target.query.get('formats')).toBe('pdf');
+      // get all values for param
+      expect(target.query.getAll('formats')).toEqual(['pdf', 'doc']);
+      expect(target.query.toString()).toBe('formats=pdf&formats=doc');
     });
   }));
 

--- a/tests/src/polyfills.ts
+++ b/tests/src/polyfills.ts
@@ -19,33 +19,37 @@
  */
 
 /** IE9, IE10 and IE11 requires all of the following polyfills. **/
-// import 'core-js/es6/symbol';
-// import 'core-js/es6/object';
-// import 'core-js/es6/function';
-// import 'core-js/es6/parse-int';
-// import 'core-js/es6/parse-float';
-// import 'core-js/es6/number';
-// import 'core-js/es6/math';
-// import 'core-js/es6/string';
-// import 'core-js/es6/date';
-// import 'core-js/es6/array';
-// import 'core-js/es6/regexp';
-// import 'core-js/es6/map';
-// import 'core-js/es6/set';
+import 'core-js/es6/symbol';
+import 'core-js/es6/object';
+import 'core-js/es6/function';
+import 'core-js/es6/parse-int';
+import 'core-js/es6/parse-float';
+import 'core-js/es6/number';
+import 'core-js/es6/math';
+import 'core-js/es6/string';
+import 'core-js/es6/date';
+import 'core-js/es6/array';
+import 'core-js/es6/regexp';
+import 'core-js/es6/map';
+import 'core-js/es6/weak-map';
+import 'core-js/es6/set';
 
 /** IE10 and IE11 requires the following for NgClass support on SVG elements */
 // import 'classlist.js';  // Run `npm install --save classlist.js`.
 
-/** IE10 and IE11 requires the following to support `@angular/animation`. */
-// import 'web-animations-js';  // Run `npm install --save web-animations-js`.
+/** IE10 and IE11 requires the following for the Reflect API. */
+import 'core-js/es6/reflect';
 
 
 /** Evergreen browsers require these. **/
-import 'core-js/es6/reflect';
+// Used for reflect-metadata in JIT. If you use AOT (and only Angular decorators), you can remove.
 import 'core-js/es7/reflect';
 
 
-/** ALL Firefox browsers require the following to support `@angular/animation`. **/
+/**
+ * Required to support Web Animations `@angular/animation`.
+ * Needed for: All but Chrome, Firefox and Opera. http://caniuse.com/#feat=web-animation
+ **/
 // import 'web-animations-js';  // Run `npm install --save web-animations-js`.
 
 
@@ -66,3 +70,7 @@ import 'zone.js/dist/zone';  // Included with Angular CLI.
  * Needed for: All but Chrome, Firefox, Edge, IE11 and Safari 10
  */
 // import 'intl';  // Run `npm install --save intl`.
+/**
+ * Need to import at least one locale-data with intl.
+ */
+// import 'intl/locale-data/jsonp/en';


### PR DESCRIPTION
URLSearchParams are not compatible with IE11 and other browsers otherwise supported by angular. See https://caniuse.com/#search=URLSearchParams
HttpParams supports the same methods as URLSearchParams, so the transition should be easy (The tests of `@plone/restapi-angular` runs without modification).
HttpParams do not encode: `@ : $ , ; + = ? /` - see the source of angular - common/http/src/params.ts